### PR TITLE
Don't ignore images

### DIFF
--- a/quotequail/__init__.py
+++ b/quotequail/__init__.py
@@ -136,9 +136,9 @@ def unwrap_html(html):
             'type': typ,
         }
 
-        top_range = _html.trim_slice(lines, top_range)
-        main_range = _html.trim_slice(lines, main_range)
-        bottom_range = _html.trim_slice(lines, bottom_range)
+        top_range = _html.trim_slice(lines, top_range, start_refs, end_refs)
+        main_range = _html.trim_slice(lines, main_range, start_refs, end_refs)
+        bottom_range = _html.trim_slice(lines, bottom_range, start_refs, end_refs)
 
         if top_range:
             top_tree = _html.slice_tree(tree, start_refs, end_refs, top_range,

--- a/tests/test_quotequail.py
+++ b/tests/test_quotequail.py
@@ -733,6 +733,16 @@ Thanks a lot!<br>
             'html_bottom': '<html><head></head><body><div class="gmail_extra">-- <br><div class="gmail_signature"><div dir="ltr"><div><div dir="ltr"><b>John Doe</b></div><div dir="ltr"><b>Senior Director</b><div>Some Company</div></div></div></div></div>\n</div>\n</body></html>',
         })
 
+    def test_reply_with_image(self):
+        html = "Test 2.<br><br>On Jun 05, 2018, at 09:56 AM, John Doe &lt;john@example.com&gt; wrote:<br><blockquote><img src=\"https://example.com\" class=\"fr-fic fr-dib\"><br>Some text 1.<br><br>Bart</blockquote>"
+        self.assertEqual(unwrap_html(html), {
+            'date': 'Jun 05, 2018, at 09:56 AM',
+            'from': 'John Doe <john@example.com>',
+            'html': u'<div><img src=\"https://example.com\" class=\"fr-fic fr-dib\"><br>Some text 1.<br><br>Bart</div>',
+            'html_top': u'Test 2.',
+            'type': 'reply'
+        })
+
     def test_outlook_forward(self):
         data = self.read_file('outlook_forward.html')
         result = unwrap_html(data)


### PR DESCRIPTION
Image in beginning of reply is incorrectly ignored. Fix.

This is a copy of [PR](https://github.com/closeio/quotequail/pull/26) by @andreip

In his words:
> Couldn't think of a different approach, since an img isn't really a block, so it'll never have a text within it, so no point in generating a different html in get_line_info functions. Instead, what was missing was it being treated as a special case: don't want to slice a line from the HTML by just looking at the plain text lines, since that could slice an img, need to also look at the start/end refs for replaced tags.
> 
> See more about a replaced element (https://developer.mozilla.org/en-US/docs/Web/CSS/Replaced_element). I think it might be worth adding a few more things to the list? e.g. video, embed etc. ; not sure about iframe and how that'd be treated in lxml parsing though, but I suppose you could have an iframe with just an image in it, in which case you'd still want to keep it?
> 
> Full list would be a total of 9 replaced elements (or 10 if we also count input; although I'm not sure of all examples where that'd generate sth even if it apparently has no text in it).